### PR TITLE
add functions to create carbon file from array_it

### DIFF
--- a/src/jakson/carbon.h
+++ b/src/jakson/carbon.h
@@ -205,6 +205,9 @@ fn_result carbon_create_empty_ex(carbon *doc, carbon_list_derivable_e derivation
 
 bool carbon_from_json(carbon *doc, const char *json, carbon_key_e type, const void *key, err *err);
 bool carbon_from_raw_data(carbon *doc, err *err, const void *data, u64 len);
+bool carbon_from_array_it(carbon *doc, carbon_array_it *it_in);
+bool carbon_from_array_it_array_insert(carbon_insert *ins, carbon_array_it *it_in);
+bool carbon_from_array_it_object_insert(carbon_insert *ins, carbon_object_it *it_in);
 
 bool carbon_drop(carbon *doc);
 

--- a/src/jakson/carbon/field.c
+++ b/src/jakson/carbon/field.c
@@ -191,6 +191,12 @@ bool carbon_field_type_is_signed(carbon_field_type_e type)
                 type == CARBON_FIELD_DERIVED_COLUMN_I64_SORTED_SET);
 }
 
+bool carbon_field_type_is_signed_atom(carbon_field_type_e type)
+{
+        return (type == CARBON_FIELD_NUMBER_I8 || type == CARBON_FIELD_NUMBER_I16 ||
+                type == CARBON_FIELD_NUMBER_I32 || type == CARBON_FIELD_NUMBER_I64);
+}
+
 bool carbon_field_type_is_unsigned(carbon_field_type_e type)
 {
         return (type == CARBON_FIELD_NUMBER_U8 || type == CARBON_FIELD_NUMBER_U16 ||
@@ -213,6 +219,12 @@ bool carbon_field_type_is_unsigned(carbon_field_type_e type)
                 type == CARBON_FIELD_DERIVED_COLUMN_U64_SORTED_SET);
 }
 
+bool carbon_field_type_is_unsigned_atom(carbon_field_type_e type)
+{
+        return (type == CARBON_FIELD_NUMBER_U8 || type == CARBON_FIELD_NUMBER_U16 ||
+                type == CARBON_FIELD_NUMBER_U32 || type == CARBON_FIELD_NUMBER_U64); 
+}
+
 bool carbon_field_type_is_floating(carbon_field_type_e type)
 {
         return (type == CARBON_FIELD_NUMBER_FLOAT || type == CARBON_FIELD_COLUMN_FLOAT_UNSORTED_MULTISET ||
@@ -221,14 +233,29 @@ bool carbon_field_type_is_floating(carbon_field_type_e type)
                 type == CARBON_FIELD_DERIVED_COLUMN_FLOAT_SORTED_SET);
 }
 
+bool carbon_field_type_is_floating_atom(carbon_field_type_e type)
+{
+        return (type == CARBON_FIELD_NUMBER_FLOAT);
+}
+
 bool carbon_field_type_is_number(carbon_field_type_e type)
 {
         return carbon_field_type_is_integer(type) || carbon_field_type_is_floating(type);
 }
 
+bool carbon_field_type_is_number_atom(carbon_field_type_e type)
+{
+        return carbon_field_type_is_integer_atom(type) || carbon_field_type_is_floating_atom(type);
+}
+
 bool carbon_field_type_is_integer(carbon_field_type_e type)
 {
         return carbon_field_type_is_signed(type) || carbon_field_type_is_unsigned(type);
+}
+
+bool carbon_field_type_is_integer_atom(carbon_field_type_e type)
+{
+        return carbon_field_type_is_signed_atom(type) || carbon_field_type_is_unsigned_atom(type);
 }
 
 bool carbon_field_type_is_binary(carbon_field_type_e type)
@@ -245,6 +272,11 @@ bool carbon_field_type_is_boolean(carbon_field_type_e type)
                 type == CARBON_FIELD_DERIVED_COLUMN_BOOLEAN_SORTED_SET);
 }
 
+bool carbon_field_type_is_boolean_atom(carbon_field_type_e type)
+{
+        return (type == CARBON_FIELD_TRUE || type == CARBON_FIELD_FALSE); 
+}
+
 bool carbon_field_type_is_string(carbon_field_type_e type)
 {
         return (type == CARBON_FIELD_STRING);
@@ -253,6 +285,11 @@ bool carbon_field_type_is_string(carbon_field_type_e type)
 bool carbon_field_type_is_constant(carbon_field_type_e type)
 {
         return (carbon_field_type_is_null(type) || carbon_field_type_is_boolean(type));
+}
+
+bool carbon_field_type_is_constant_atom(carbon_field_type_e type)
+{
+        return (carbon_field_type_is_null(type) || carbon_field_type_is_boolean_atom(type));
 }
 
 bool carbon_field_skip(memfile *file)

--- a/src/jakson/carbon/field.h
+++ b/src/jakson/carbon/field.h
@@ -222,12 +222,18 @@ const char *carbon_field_type_str(err *err, carbon_field_type_e type);
 
 bool carbon_field_type_is_traversable(carbon_field_type_e type);
 bool carbon_field_type_is_signed(carbon_field_type_e type);
+bool carbon_field_type_is_signed_atom(carbon_field_type_e type);
 bool carbon_field_type_is_unsigned(carbon_field_type_e type);
+bool carbon_field_type_is_unsigned_atom(carbon_field_type_e type);
 bool carbon_field_type_is_floating(carbon_field_type_e type);
+bool carbon_field_type_is_floating_atom(carbon_field_type_e type);
 bool carbon_field_type_is_number(carbon_field_type_e type);
+bool carbon_field_type_is_number_atom(carbon_field_type_e type);
 bool carbon_field_type_is_integer(carbon_field_type_e type);
+bool carbon_field_type_is_integer_atom(carbon_field_type_e type);
 bool carbon_field_type_is_binary(carbon_field_type_e type);
 bool carbon_field_type_is_boolean(carbon_field_type_e type);
+bool carbon_field_type_is_boolean_atom(carbon_field_type_e type);
 bool carbon_field_type_is_list_or_subtype(carbon_field_type_e type);
 bool carbon_field_type_is_array_or_subtype(carbon_field_type_e type);
 bool carbon_field_type_is_column_u8_or_subtype(carbon_field_type_e type);
@@ -245,6 +251,7 @@ bool carbon_field_type_is_object_or_subtype(carbon_field_type_e type);
 bool carbon_field_type_is_null(carbon_field_type_e type);
 bool carbon_field_type_is_string(carbon_field_type_e type);
 bool carbon_field_type_is_constant(carbon_field_type_e type);
+bool carbon_field_type_is_constant_atom(carbon_field_type_e type);
 
 carbon_field_class_e carbon_field_type_get_class(carbon_field_type_e type, err *err);
 

--- a/src/jakson/carbon/object_it.c
+++ b/src/jakson/carbon/object_it.c
@@ -90,6 +90,21 @@ bool carbon_object_it_clone(carbon_object_it *dst, carbon_object_it *src)
         return true;
 }
 
+bool carbon_object_it_length(u64 *len, carbon_object_it *it) {
+
+    ERROR_IF_NULL(len);
+    ERROR_IF_NULL(it);
+
+    u64 num_elem = 0;
+    carbon_object_it_rewind(it);
+    while (carbon_object_it_next(it)) {
+        num_elem++;
+    }
+    *len = num_elem;
+
+    return true;
+}
+        
 bool carbon_object_it_drop(carbon_object_it *it)
 {
         carbon_int_field_auto_close(&it->field.value.data);

--- a/src/jakson/carbon/object_it.h
+++ b/src/jakson/carbon/object_it.h
@@ -61,6 +61,7 @@ typedef struct carbon_object_it {
 bool carbon_object_it_create(carbon_object_it *it, memfile *memfile, err *err, offset_t payload_start);
 bool carbon_object_it_copy(carbon_object_it *dst, carbon_object_it *src);
 bool carbon_object_it_clone(carbon_object_it *dst, carbon_object_it *src);
+bool carbon_object_it_length(u64 *len, carbon_object_it *oit);
 bool carbon_object_it_drop(carbon_object_it *it);
 
 bool carbon_object_it_rewind(carbon_object_it *it);


### PR DESCRIPTION
Adds functions for creating a carbon file from an array iterator.
Cherry-picked commit https://github.com/jaksonlabs/jakson/pull/4/commits/442493207ded119bef22e21bb1e850c9e5b640b7, so you might want to review https://github.com/jaksonlabs/jakson/pull/4 first.
Also cherry-picked commit 656b21689f7295f3726bb9f81571f8a300ca1661 from https://github.com/jaksonlabs/jakson/pull/1.